### PR TITLE
Feature/update to swift 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/SwiftClamping/Clamping.swift
+++ b/Sources/SwiftClamping/Clamping.swift
@@ -9,8 +9,8 @@ import Foundation
 
 @propertyWrapper
 public struct Clamping<T> where T:Comparable {
-    private(set) var value: T
-    var range: ClosedRange<T>
+    private var value: T
+    private let range: ClosedRange<T>
     public var wrappedValue: T {
         get {
             return value
@@ -19,14 +19,6 @@ public struct Clamping<T> where T:Comparable {
             value = clamp(newValue)
         }
     }
-    
-    public var projectedValue: ClosedRange<T> {
-        get { range }
-        set {
-            range = newValue
-            value = clamp(value)
-        }
-      }
     
     private func clamp(_ v: T) -> T {
         max(min(v, range.upperBound), range.lowerBound)

--- a/SwiftClamping.podspec
+++ b/SwiftClamping.podspec
@@ -8,10 +8,10 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftClamping'
-  s.version          = '1.0.1'
+  s.version          = '1.1.0'
   s.summary          = 'A property wrapper to limit input range.'
 # s.swift_version:begin
-  s.swift_version  = '5.9.0'
+  s.swift_version  = '6.1.0'
   # s.swift_version    = '${SWIFT_VERSION}'
 
 # s.platform:begin

--- a/Tests/SwiftClampingTests/ClampingTests.swift
+++ b/Tests/SwiftClampingTests/ClampingTests.swift
@@ -2,8 +2,13 @@ import XCTest
 @testable import SwiftClamping
 
 final class ClampingTests: XCTestCase {
+    
+    func clampingArg(@Clamping(0.0...1.0) _ arg: CGFloat) {
+        debugPrint("clamping \(arg), projected: \($arg)")
+    }
+    
     func testExample() throws {
-        
+        XCTAssertNoThrow(clampingArg(0.8))
         @Clamping(0...10) var clampedInt: Int = 0
         clampedInt = 100
         XCTAssertEqual(clampedInt, 10)


### PR DESCRIPTION
1. Update swift version to 6.1
2. Apply workaround for swiftcompile crash when IRGen.
    1. Occurs when apply a property wrapper with writable projected value on function/closure parameter.
    2. Workaround: 
        1. use a class to wrap projected value, and modify projected value through the wrap class. 
        2. declare the setter of projected value as nonmutating.
3. Refactoring implementation of `@clamping` to simplify it.